### PR TITLE
Allow consumers to disable config caching.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+vendor/bundle
+.ruby-version

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ show_new_ui:
 In a Rails application, first add the middleware in `application.rb`
 
 ```ruby
-config.middleware.use RackFlags::RackMiddleware, yaml_path: File.expand_path('../feature_flags.yaml',__FILE__)
+config.middleware.use RackFlags::RackMiddleware, yaml_path: File.expand_path('../feature_flags.yaml',__FILE__), disable_config_caching: Rails.env.development?
 ```
 
 Then, mount the AdminApp to some route in `routes.rb`

--- a/lib/rack-flags/rack_middleware.rb
+++ b/lib/rack-flags/rack_middleware.rb
@@ -4,16 +4,22 @@ module RackFlags
 
     def initialize( app, args )
       @app = app
-      yaml_path = args.fetch( :yaml_path ){ raise ArgumentError.new( 'yaml_path must be provided' ) }
-      @config = Config.load( yaml_path )
+      @disable_config_caching = args.fetch(:disable_config_caching, false)
+      @yaml_path = args.fetch( :yaml_path ){ raise ArgumentError.new( 'yaml_path must be provided' ) }
     end
 
     def call( env )
       overrides = CookieCodec.new.overrides_from_env( env )
-      reader = Reader.new( @config.flags, overrides )
+      reader = Reader.new( config.flags, overrides )
       env[ENV_KEY] = reader
 
       @app.call(env)
+    end
+
+    private
+    def config
+      @config = nil if @disable_config_caching
+      @config ||= Config.load(@yaml_path)
     end
   end
 end

--- a/lib/rack-flags/version.rb
+++ b/lib/rack-flags/version.rb
@@ -1,3 +1,3 @@
 module RackFlags
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 end

--- a/rack-flags.gemspec
+++ b/rack-flags.gemspec
@@ -25,8 +25,9 @@ Gem::Specification.new do |gem|
 
   gem.add_development_dependency( "pry-debugger" )
 
-  gem.add_development_dependency( "rspec-core" )
-  gem.add_development_dependency( "rspec-expectations" )
+  gem.add_development_dependency( "rspec" )
+  gem.add_development_dependency( "rspec-its" )
+  gem.add_development_dependency( "rspec-collection_matchers" )
   gem.add_development_dependency( "rr" )
   gem.add_development_dependency( "capybara" )
 end

--- a/spec/acceptance/support/page_objects/admin_page.rb
+++ b/spec/acceptance/support/page_objects/admin_page.rb
@@ -60,7 +60,6 @@ class AdminPage
   end
 
   def verify_status_code_is(expected_status_code)
-    status_code.should == expected_status_code
+    expect(status_code).to eql expected_status_code
   end
-
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@ require 'rr'
 require 'pry'
 require 'rack'
 require 'rack/test'
+require 'rspec/its'
+require 'rspec/collection_matchers'
 
 require_relative '../lib/rack-flags'
 

--- a/spec/unit/config_spec.rb
+++ b/spec/unit/config_spec.rb
@@ -57,7 +57,7 @@ module RackFlags
       subject(:flag){ config.flags.first } 
 
       it { should_not be_nil }
-      its(:default) { should be_true }
+      its(:default) { should be_truthy }
       its(:description) { should == "a description" }
     end
   end

--- a/spec/unit/reader_spec.rb
+++ b/spec/unit/reader_spec.rb
@@ -29,11 +29,11 @@ module RackFlags
 
         expect(full_flags[0].name).to eq(:usually_on)
         expect(full_flags[0].description).to eq('a flag')
-        expect(full_flags[0].default).to be_true
+        expect(full_flags[0].default).to be_truthy
 
         expect(full_flags[1].name).to eq(:usually_off)
         expect(full_flags[1].description).to eq('another flag')
-        expect(full_flags[1].default).to be_false
+        expect(full_flags[1].default).to be_falsey
       end
 
     end
@@ -44,15 +44,15 @@ module RackFlags
       its(:base_flags){ should == {usually_on: true, usually_off: false} }
 
       specify 'on? is true for a flag which is on by default' do
-        subject.on?( :usually_on ).should be_true
+        subject.on?( :usually_on ).should be_truthy
       end
 
       specify 'on? is false for a flag which is off by default' do
-        subject.on?( :usually_off ).should be_false
+        subject.on?( :usually_off ).should be_falsey
       end
 
       specify 'on? is false for unknown flags' do
-        subject.on?( :unknown_flag ).should be_false
+        subject.on?( :unknown_flag ).should be_falsey
       end
 
       it_behaves_like 'full flags that mimic the base flags'
@@ -68,7 +68,7 @@ module RackFlags
       let( :overrides ){ {usually_on: false} }
 
       specify 'on? is false' do
-        subject.on?( :usually_on ).should be_false
+        subject.on?( :usually_on ).should be_falsey
       end
 
       it_behaves_like 'full flags that mimic the base flags'
@@ -84,7 +84,7 @@ module RackFlags
       let( :overrides ){ {no_base: true} }
 
       specify 'on? is false' do
-        subject.on?( :no_base ).should be_false
+        subject.on?( :no_base ).should be_falsy
       end
 
       it_behaves_like 'full flags that mimic the base flags'
@@ -96,5 +96,4 @@ module RackFlags
       end
     end
   end
-
 end


### PR DESCRIPTION
During development, it's convenient if the configuration file is re-read every request.  This version would add support for a configuration option that disables caching.
